### PR TITLE
Implement localStorage-based login/register

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,6 +15,7 @@ import TheWelcome from './components/TheWelcome.vue'
   <main>
     <TheWelcome/>
     <nav>
+      <router-link to="/home">首页</router-link> |
       <router-link to="/login">登录</router-link> |
       <router-link to="/register">注册</router-link>
     </nav>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="home">
+    <h2>首页</h2>
+    <p v-if="user">欢迎 {{ user.name }}</p>
+    <p v-else>
+      请 <router-link to="/login">登录</router-link>
+      或 <router-link to="/register">注册</router-link>
+    </p>
+    <button v-if="user" @click="logout">退出登录</button>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return { user: null };
+  },
+  created() {
+    const saved = localStorage.getItem('currentUser');
+    if (saved) {
+      this.user = JSON.parse(saved);
+    }
+  },
+  methods: {
+    logout() {
+      localStorage.removeItem('currentUser');
+      this.user = null;
+    }
+  }
+};
+</script>
+
+<style scoped>
+.home {
+  text-align: center;
+}
+</style>

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -22,8 +22,17 @@ export default {
   },
   methods: {
     handleLogin() {
-      // 登录逻辑处理（如调用API）
-      console.log('登录数据:', this.form);
+      const users = JSON.parse(localStorage.getItem('users') || '[]')
+      const user = users.find(
+        (u) => u.email === this.form.email && u.password === this.form.password
+      )
+      if (user) {
+        localStorage.setItem('currentUser', JSON.stringify(user))
+        alert('登录成功')
+        this.$router.push('/home')
+      } else {
+        alert('邮箱或密码错误')
+      }
     }
   }
 };

--- a/src/components/Register.vue
+++ b/src/components/Register.vue
@@ -24,8 +24,15 @@ export default {
   },
   methods: {
     handleRegister() {
-      // 注册逻辑处理（如调用API）
-      console.log('注册数据:', this.form);
+      const users = JSON.parse(localStorage.getItem('users') || '[]')
+      if (users.some((u) => u.email === this.form.email)) {
+        alert('邮箱已存在')
+        return
+      }
+      users.push({ ...this.form })
+      localStorage.setItem('users', JSON.stringify(users))
+      alert('注册成功，请登录')
+      this.$router.push('/login')
     }
   }
 };

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,11 +3,13 @@ import { createRouter, createWebHistory } from 'vue-router'
 
 import Login from '../components/Login.vue'
 import Register from '../components/Register.vue'
+import Home from '../components/Home.vue'
 
 const routes = [
-
-    { path: '/login', component: Login },
-    { path: '/register', component: Register }
+  { path: '/', component: Home },
+  { path: '/home', component: Home },
+  { path: '/login', component: Login },
+  { path: '/register', component: Register }
 ]
 
 const router = createRouter({


### PR DESCRIPTION
## Summary
- implement simple Home page
- wire up login with local storage
- add registration data persistence
- update router to include home path
- show Home link in main navigation

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842748150648332a55702ef1a96252d